### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build and test
+permissions:
+  contents: read
 
 # Controls when the workflow should run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/miguelandres/bday_reminders/security/code-scanning/1](https://github.com/miguelandres/bday_reminders/security/code-scanning/1)

To fix this issue, you should add an explicit `permissions` block to your workflow to restrict the default access of the `GITHUB_TOKEN`. As a minimal starting point, set `contents: read` at the workflow root, which is sufficient for jobs that only clone, build, and test code and do not write to the repository or interact with issues or pull requests. 

Specifically, insert the `permissions:` block at the top level of the YAML file (just after the `name:` line and before `on:`). This change will ensure all jobs in the workflow inherit the minimal required permissions, aligning with the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
